### PR TITLE
swap to calculating inbreeding as per gnomad

### DIFF
--- a/config/sites_table_defaults.toml
+++ b/config/sites_table_defaults.toml
@@ -4,6 +4,7 @@
 name = 'sandbox'
 sequencing_type = 'genome'
 only_states = ['GenerateSitesTable']
+input_cohorts = ["COH0000"]
 
 # used to make sure we don't repeat previously completed stages
 check_expected_outputs = true
@@ -22,6 +23,7 @@ external_sites_filter_table_path = 'gs://cpg-common-main/references/gnomad/v4.1/
 subsample = false
 subsample_n = 500000
 sites_table_outpath = 'gs://cpg-common-main/references/ancestry/hgdp-1kg-wgs-pruned_variants.ht'
+chromosome_list = ['chr21']
 
 # Metrics for filtering
 allele_frequency_min = 0.01

--- a/src/sandbox/gnomad_methods/bi_allelic_sites_inbreeding.py
+++ b/src/sandbox/gnomad_methods/bi_allelic_sites_inbreeding.py
@@ -1,0 +1,51 @@
+import hail as hl
+
+
+def bi_allelic_site_inbreeding_expr(
+    call: hl.expr.CallExpression | None = None,
+    callstats_expr: hl.expr.StructExpression | None = None,
+) -> hl.expr.Float32Expression:
+    """
+    Return the site inbreeding coefficient as an expression to be computed on a MatrixTable.
+
+    This is implemented based on the GATK InbreedingCoeff metric:
+    https://software.broadinstitute.org/gatk/documentation/article.php?id=8032
+
+    .. note::
+
+        The computation is run based on the counts of alternate alleles and thus should only be run on bi-allelic sites.
+
+    :param call: Expression giving the calls in the MT
+    :param callstats_expr: StructExpression containing only alternate allele AC, AN, and homozygote_count as integers. If passed, used to create expression in place of GT calls.
+    :return: Site inbreeding coefficient expression
+    """
+    if call is None and callstats_expr is None:
+        raise ValueError('One of `call` or `callstats_expr` must be passed.')
+
+    def inbreeding_coeff(
+        gt_counts: hl.expr.DictExpression,
+    ) -> hl.expr.Float32Expression:
+        n = gt_counts.get(0, 0) + gt_counts.get(1, 0) + gt_counts.get(2, 0)
+        p = (2 * gt_counts.get(0, 0) + gt_counts.get(1, 0)) / (2 * n)
+        q = (2 * gt_counts.get(2, 0) + gt_counts.get(1, 0)) / (2 * n)
+        return 1 - (gt_counts.get(1, 0) / (2 * p * q * n))
+
+    if callstats_expr is not None:
+        # Check that AC, AN, and homozygote count are all ints
+        if not (
+            ((callstats_expr.AC.dtype == hl.tint32) | (callstats_expr.AC.dtype == hl.tint64))
+            & ((callstats_expr.AN.dtype == hl.tint32) | (callstats_expr.AN.dtype == hl.tint64))
+            & (
+                (callstats_expr.homozygote_count.dtype == hl.tint32)
+                | (callstats_expr.homozygote_count.dtype == hl.tint64)
+            )
+        ):
+            raise ValueError(
+                "callstats_expr must be a StructExpression containing fields 'AC',"
+                " 'AN', and 'homozygote_count' of types int32 or int64."
+            )
+        n = callstats_expr.AN / 2
+        q = callstats_expr.AC / callstats_expr.AN
+        p = 1 - q
+        return 1 - (callstats_expr.AC - (2 * callstats_expr.homozygote_count)) / (2 * p * q * n)
+    return hl.bind(inbreeding_coeff, hl.agg.counter(call.n_alt_alleles()))

--- a/src/sandbox/jobs/generate_sites_table.py
+++ b/src/sandbox/jobs/generate_sites_table.py
@@ -5,6 +5,7 @@ from cpg_flow.targets import Cohort
 from cpg_flow.utils import to_path  # type: ignore[ReportUnknownVariableType]
 from cpg_utils.config import config_retrieve, genome_build, get_driver_image
 from cpg_utils.hail_batch import get_batch, init_batch, output_path  # type: ignore[ReportUnknownVariableType]
+from gnomad_methods.bi_allelic_sites_inbreeding import bi_allelic_site_inbreeding_expr
 from hailtop.batch.job import PythonJob, PythonResult
 from loguru import logger
 
@@ -158,9 +159,8 @@ def _run_sites_per_chromosome(cohort_name: str, chromosome: str) -> str:  # noqa
 
             logger.info('Done running variant QC. Now generating sites table and filtering using gnomAD v3 parameters')
             cohort_dense_mt = cohort_dense_mt.annotate_rows(
-                IB=hl.agg.inbreeding(
+                IB=bi_allelic_site_inbreeding_expr(
                     cohort_dense_mt.GT,
-                    cohort_dense_mt.variant_qc.AF[1],
                 ),
             )
             cohort_dense_mt = cohort_dense_mt.filter_rows(


### PR DESCRIPTION
# Purpose

  - There seems to be an issue with `hail.agg.inbreeding`, so we are swapping to use the method defined in gnomAD methods. Hail checks to see that the site is biallelic, gnomAD just assumes that it is.

## Proposed Changes

  - Copy over relevant method
  - Swap to using gnomAD method
