### PR TITLE
Pre-filter the VDS based on provided list(s) of samples to drop.

### DIFF
--- a/config/sites_table_defaults.toml
+++ b/config/sites_table_defaults.toml
@@ -25,6 +25,9 @@ subsample_n = 500000
 sites_table_outpath = 'gs://cpg-common-main/references/ancestry/hgdp-1kg-wgs-pruned_variants.ht'
 chromosome_list = ['chr21']
 
+# Sample filtering
+samples_to_drop = []
+
 # Metrics for filtering
 allele_frequency_min = 0.01
 call_rate_min = 0.99


### PR DESCRIPTION
# Purpose

  - Enable the VDS to be filtered to remove related and low-quality samples prior to site selection.

## Proposed Changes

  - Add a config parameter to pass a list of hail tables containing the samples to drop
  - Create the union of these hail tables, then use it to filter the VDS
