### PR TITLE
Fix bi_allelic_site_inbreeding_expr import

### DIFF
--- a/src/sandbox/jobs/generate_sites_table.py
+++ b/src/sandbox/jobs/generate_sites_table.py
@@ -5,7 +5,7 @@ from cpg_flow.targets import Cohort
 from cpg_flow.utils import to_path  # type: ignore[ReportUnknownVariableType]
 from cpg_utils.config import config_retrieve, genome_build, get_driver_image
 from cpg_utils.hail_batch import get_batch, init_batch, output_path  # type: ignore[ReportUnknownVariableType]
-from gnomad_methods.bi_allelic_sites_inbreeding import bi_allelic_site_inbreeding_expr
+from ..gnomad_methods.bi_allelic_sites_inbreeding import bi_allelic_site_inbreeding_expr
 from hailtop.batch.job import PythonJob, PythonResult
 from loguru import logger
 
@@ -177,7 +177,7 @@ def _run_sites_per_chromosome(cohort_name: str, chromosome: str) -> str:  # noqa
                 & (cohort_dense_mt.locus.in_autosome())
                 & (cohort_dense_mt.variant_qc.AF[1] > allele_frequency_min)
                 & (cohort_dense_mt.variant_qc.call_rate > call_rate_min)
-                & (cohort_dense_mt.IB.f_stat > f_stat)
+                & (cohort_dense_mt.IB > f_stat)
                 & (cohort_dense_mt.variant_qc.p_value_hwe > p_value_hwe)
             )
             logger.info('Done filtering using gnomAD v3 parameters')


### PR DESCRIPTION
# Purpose

Fixes to the import and use of bi_allelic_site_inbreeding_expr so we can run this script to evaluate test parameters. A proper import from gnomad utils is required in the future.

## Proposed Changes

  - Point to the local bi_allelic_site_inbreeding_expr code
  - Adjust the filtering expression based on the new metric format

