### PR TITLE
Repartition the matrix table after filtering.

### DIFF
--- a/config/sites_table_defaults.toml
+++ b/config/sites_table_defaults.toml
@@ -28,6 +28,9 @@ chromosome_list = ['chr21']
 # Sample filtering
 samples_to_drop = []
 
+# Repartition post variant filtering
+n_partitions = 10
+
 # Metrics for filtering
 allele_frequency_min = 0.01
 call_rate_min = 0.99

--- a/src/sandbox/jobs/generate_sites_table.py
+++ b/src/sandbox/jobs/generate_sites_table.py
@@ -75,6 +75,8 @@ def _run_sites_per_chromosome(cohort_name: str, chromosome: str) -> str:  # noqa
 
     samples_to_drop = config_retrieve(['generate_sites_table', 'samples_to_drop'])
 
+    n_partitions = config_retrieve(['generate_sites_table', 'n_partitions'])
+
     allele_frequency_min: float = config_retrieve(['generate_sites_table', 'allele_frequency_min'])
     call_rate_min: float = config_retrieve(['generate_sites_table', 'call_rate_min'])
     f_stat: float = config_retrieve(['generate_sites_table', 'f_stat'])
@@ -197,6 +199,10 @@ def _run_sites_per_chromosome(cohort_name: str, chromosome: str) -> str:  # noqa
                     subsample_n / nrows,
                     seed=12345,
                 )
+
+            # Repartition the matrix table to account for our aggressive variant filtering.
+            logger.info('Repartioning the sites table pre-LD pruning')
+            cohort_dense_mt = cohort_dense_mt.repartition(n_partitions)
 
             logger.info('Writing sites table pre-LD pruning')
             cohort_dense_mt = cohort_dense_mt.checkpoint(pre_ld_prune_path, overwrite=True)


### PR DESCRIPTION
# Purpose

  - Our dataset has undergone very aggressive filtering, so we need to repartition the matrix table to avoid excessive computational overhead from processing many thousands of tiny partitions.

## Proposed Changes

  - Allow n_partitions to be provided as a config parameter (as we may want different partitions for exomes vs genomes, or across chromosomes).
  - Use this parameter to repartition the matrix table after filtering, before writing.
