### PR TITLE
Before densifying the VDS, checkpoint the filtered version.

### DIFF
--- a/src/sandbox/jobs/generate_sites_table.py
+++ b/src/sandbox/jobs/generate_sites_table.py
@@ -90,6 +90,10 @@ def _run_sites_per_chromosome(cohort_name: str, chromosome: str) -> str:  # noqa
 
     init_batch()
 
+    filtered_vds_path: str = output_path(
+        f'cohort{cohort_name}_{chromosome}_vds_{"exome_" if exomes else ""}filtered.vds', 'tmp'
+    )
+
     pre_ld_prune_path: str = output_path(
         f'cohort{cohort_name}_{chromosome}_dense_mt_{"exome_" if exomes else ""}pre_pruning.mt', 'tmp'
     )
@@ -99,43 +103,56 @@ def _run_sites_per_chromosome(cohort_name: str, chromosome: str) -> str:  # noqa
 
     if not to_path(post_ld_prune_outpath).exists():
         if not to_path(pre_ld_prune_path).exists():
-            external_sites_table: hl.Table = hl.read_table(external_sites_filter_table_path)
+            if not to_path(filtered_vds_path).exists():
+                # exomes
+                if exomes:
+                    if not intersected_bed_file:
+                        raise ValueError('If --exomes is set, you must provide at least one --capture-region-bed-files')
+                    # Read in capture region bed files
+                    capture_interval_ht: hl.Table = hl.import_bed(
+                        str(intersected_bed_file), reference_genome=genome_build()
+                    )
+                    # Generate list of intervals
+                    intervals = capture_interval_ht.interval.collect()
+
+                tmp_intervals: list[hl.Interval] = []
+                if not intervals:
+                    tmp_intervals = [hl.eval(hl.parse_locus_interval(chromosome, reference_genome=genome_build()))]
+                else:
+                    for interval in intervals:
+                        if interval.start.contig == chromosome:
+                            tmp_intervals.append(interval)
+
+                filtering_intervals: list[hl.Interval] = hl.eval(hl.array(tmp_intervals))
+
+                # Read VDS then filter, to avoid ref blocks that span intervals being dropped silently
+                vds: VariantDataset = hl.vds.read_vds(str(vds_path))
+                vds = hl.vds.filter_intervals(vds, filtering_intervals, split_reference_blocks=False)
+
+                # Remove samples that are present in the samples_to_drop list
+                sample_hts = [hl.read_table(path) for path in samples_to_drop]
+                all_samples_to_drop = sample_hts[0]
+                for ht in sample_hts[1:]:
+                    all_samples_to_drop = all_samples_to_drop.union(ht)
+                vds = hl.vds.filter_samples(vds, all_samples_to_drop, keep=False)
+
+                # Checkpoint the VDS after filtering on samples, chromosome, and exome regions.
+                logger.info('Checkpointing filtered VDS')
+                vds = vds.checkpoint(filtered_vds_path)
+                logger.info('Done checkpointing filtered VDS')
+            else:
+                vds = hl.vds.read_vds(str(filtered_vds_path))
 
             # LC pipeline VQSR has AS_FilterStatus in info field. We need to annotate
             # sites in the external sites table with AS_FilterStatus if it does not exist
             # based on the `filters` field.
+            external_sites_table: hl.Table = hl.read_table(external_sites_filter_table_path)
             if 'AS_FilterStatus' not in list(external_sites_table.info.keys()):
-                # if 'AS_FilterStatus' not in [k for k in external_sites_table.info.keys()]:
                 external_sites_table = external_sites_table.annotate(
                     info=external_sites_table.info.annotate(
                         AS_FilterStatus=hl.if_else(hl.len(external_sites_table.filters) == 0, 'PASS', 'FAIL'),
                     ),
                 )
-
-            # exomes
-            if exomes:
-                if not intersected_bed_file:
-                    raise ValueError('If --exomes is set, you must provide at least one --capture-region-bed-files')
-                # Read in capture region bed files
-                capture_interval_ht: hl.Table = hl.import_bed(
-                    str(intersected_bed_file), reference_genome=genome_build()
-                )
-                # Generate list of intervals
-                intervals = capture_interval_ht.interval.collect()
-
-            tmp_intervals: list[hl.Interval] = []
-            if not intervals:
-                tmp_intervals = [hl.eval(hl.parse_locus_interval(chromosome, reference_genome=genome_build()))]
-            else:
-                for interval in intervals:
-                    if interval.start.contig == chromosome:
-                        tmp_intervals.append(interval)
-
-            filtering_intervals: list[hl.Interval] = hl.eval(hl.array(tmp_intervals))
-
-            # Read VDS then filter, to avoid ref blocks that span intervals being dropped silently
-            vds: VariantDataset = hl.vds.read_vds(str(vds_path))
-            vds = hl.vds.filter_intervals(vds, filtering_intervals, split_reference_blocks=False)
 
             # Filter to variant sites that pass VQSR
             passed_variants = external_sites_table.filter(external_sites_table.info.AS_FilterStatus == 'PASS')
@@ -148,13 +165,6 @@ def _run_sites_per_chromosome(cohort_name: str, chromosome: str) -> str:  # noqa
                 keep=True,
             )
 
-            # Remove samples that are present in the samples_to_drop list
-            sample_hts = [hl.read_table(path) for path in samples_to_drop]
-            all_samples_to_drop = sample_hts[0]
-            for ht in sample_hts[1:]:
-                all_samples_to_drop = all_samples_to_drop.union(ht)
-            vds = hl.vds.filter_samples(vds, all_samples_to_drop, keep=False)
-
             if 'GT' not in vds.variant_data.entry:
                 vds.variant_data = vds.variant_data.annotate_entries(
                     GT=hl.vds.lgt_to_gt(vds.variant_data.LGT, vds.variant_data.LA)
@@ -165,11 +175,6 @@ def _run_sites_per_chromosome(cohort_name: str, chromosome: str) -> str:  # noqa
             logger.info('Done densifying VDS. Now running variant QC')
 
             # Run variant QC
-            # choose variants based off of gnomAD v3 parameters
-            # Inbreeding coefficient > -0.80 (no excess of heterozygotes)
-            # Must be single nucleotide variants that are autosomal (i.e., no sex), and bi-allelic
-            # Have an allele frequency above 1% (note deviation from gnomAD, which is 0.1%)
-            # Have a call rate above 99%
             cohort_dense_mt = hl.variant_qc(cohort_dense_mt)
 
             logger.info('Done running variant QC. Now generating sites table and filtering using gnomAD v3 parameters')
@@ -188,11 +193,7 @@ def _run_sites_per_chromosome(cohort_name: str, chromosome: str) -> str:  # noqa
             )
             logger.info('Done filtering using gnomAD v3 parameters')
 
-            # downsize input variants for ld_prune
-            # otherwise, persisting the pruned_variant_table will cause
-            # script to fail. See https://github.com/populationgenomics/ancestry/pull/79
-
-            # subsample
+            # Optionally subsample
             if subsample:
                 if not subsample_n:
                     raise ValueError('If --subsample is set, you must provide a value for --subsample-n')
@@ -215,7 +216,6 @@ def _run_sites_per_chromosome(cohort_name: str, chromosome: str) -> str:  # noqa
         else:
             cohort_dense_mt = hl.read_matrix_table(pre_ld_prune_path)
 
-        # as per gnomAD, LD-prune variants with a cutoff of r2 = 0.1
         logger.info('Pruning sites table')
         pruned_variant_table = hl.ld_prune(
             cohort_dense_mt.GT,


### PR DESCRIPTION
# Purpose

  - As per this post [here](https://discuss.hail.is/t/most-efficient-way-to-filter-and-densify-vds/3810/2), the hail team recommends checkpointing a VDS after filtering on intervals and samples, but before performing densification. 

## Proposed Changes

  - Only generate a new filtered VDS if the checkpointed one doesn't already exist
  - Perform sample filtering straight after interval filtering, then checkpoint the result
  - Use the checkpointed table to do additional variant filtering and then densify
