### PR TITLE
Pass the somalier files as quoted glob strings for each directory

### DIFF
--- a/src/sandbox/scripts/run_somalier_relate.py
+++ b/src/sandbox/scripts/run_somalier_relate.py
@@ -8,7 +8,7 @@ This script runs somalier relate on a set of cram.somalier files provided as inp
     --access-level "full" \
     --output-dir "qc-stand-alone/tob_bioheart/somalier" \
     run_somalier_relate.py \
-    --input-dirs gs://cpg-bioheart-main/cram 
+    --input-dirs gs://cpg-bioheart-main/cram
     --input-dirs gs://cpg-tob-wgs-main/cram
 
 """
@@ -45,9 +45,7 @@ def main(job_memory, job_ncpu, job_storage, input_dirs):  # pylint: disable=miss
         input_files.extend(somalier_files)
 
     num_samples = len(input_files)
-    batch_input_files = []
-    for each_file in input_files:
-        batch_input_files.append(b.read_input(each_file))
+    somalier_input = ' '.join(f'"{path.rstrip("/") + "/*.somalier"}"' for path in input_dirs)
 
     somalier_job = b.new_job(name=f'Somalier relate: {num_samples} samples')
     somalier_job.image(SOMALIER_IMAGE)
@@ -58,7 +56,7 @@ def main(job_memory, job_ncpu, job_storage, input_dirs):  # pylint: disable=miss
     somalier_job.command(
         f"""
                 somalier relate  \\
-                {" ".join(batch_input_files)} \\
+                {somalier_input} \\
                 --infer \\
                 -o related
 


### PR DESCRIPTION
Passing each individual file results in an error, 'AssertionError: every spec must be less than max_bunch_bytesize, 1048576B'. However, according to the somalier docs, it can accept directory glob strings instead.

> For huge sample-sets, if you run into a bash error for argument list too long, you can pass the somalier files as quoted glob strings like: "/path/to/set-a/*.somalier" "/path/to/set-b/*.somalier".