### PR TITLE
Unquote glob strings

### DIFF
--- a/src/sandbox/scripts/run_somalier_relate.py
+++ b/src/sandbox/scripts/run_somalier_relate.py
@@ -45,7 +45,7 @@ def main(job_memory, job_ncpu, job_storage, input_dirs):  # pylint: disable=miss
         input_files.extend(somalier_files)
 
     num_samples = len(input_files)
-    somalier_input = ' '.join(f'"{path.rstrip("/") + "/*.somalier"}"' for path in input_dirs)
+    somalier_input = ' '.join(f'{path.rstrip("/") + "/*.somalier"}' for path in input_dirs)
 
     somalier_job = b.new_job(name=f'Somalier relate: {num_samples} samples')
     somalier_job.image(SOMALIER_IMAGE)


### PR DESCRIPTION
Although it asks for quoted glob strings, all the somalier examples are unquoted.