### PR TITLE
Export VDS to VCF

### DIFF
--- a/src/sandbox/jobs/vds_to_vcf.py
+++ b/src/sandbox/jobs/vds_to_vcf.py
@@ -374,10 +374,13 @@ def _run_vds_to_vcf(vds_path: str, vcf_outpath: str, chrm: str) -> str:
         keep=chrm,
     )
 
+    logger.info('Globalising entries')
     vds = globalise_entries(vds)
 
+    logger.info('Densifying...')
     mt = hl.vds.to_dense_mt(vds)
 
+    logger.info(f'Checkpointing dense MT to {output_path(f"{chrm}_dense_mt.mt", category="tmp")}')
     mt = mt.checkpoint(output_path(f'{chrm}_dense_mt.mt', category='tmp'), overwrite=True)
 
     if to_path(info_ht_outpath).exists():
@@ -388,9 +391,11 @@ def _run_vds_to_vcf(vds_path: str, vcf_outpath: str, chrm: str) -> str:
         info_ht = generate_info_ht(mt)
 
     # Annotate back the MT with the info HT
+    logger.info('Annotating MT with info_ht')
     mt = mt.annotate_rows(info=info_ht[mt.row_key].info)
 
     # Drop local and unnecessary fields
+    logger.info('Dropping local and unnecessary fields')
     mt = mt.drop('gvcf_info')
     mt = mt.drop('LAD', 'LGT', 'LA', 'LPL', 'LPGT')
 

--- a/src/sandbox/jobs/vds_to_vcf.py
+++ b/src/sandbox/jobs/vds_to_vcf.py
@@ -244,10 +244,7 @@ def _filter_rows_and_add_tags(mt: hl.MatrixTable) -> hl.MatrixTable:
     # locus   alleles    LGT
     # chr1:1 ["GCT","G"] 0/1
     # chr1:3 ["T","*"]   NA
-    mt = mt.filter_rows(
-        (hl.len(mt.alleles) > 1) &
-        (hl.agg.any(mt.LGT.is_non_ref()) | mt.alleles.contains('*'))
-    )
+    mt = mt.filter_rows((hl.len(mt.alleles) > 1) & (hl.agg.any(mt.LGT.is_non_ref())))
 
     # annotate site level DP as site_dp onto the mt rows to avoid name collision
     mt = mt.annotate_rows(site_dp=hl.agg.sum(mt.DP))

--- a/src/sandbox/stages.py
+++ b/src/sandbox/stages.py
@@ -65,6 +65,6 @@ class ExportVdsToVcf(CohortStage):
         vds_path: str = config_retrieve(['export_vds_to_vcf', 'vds_path'])
 
         for chrom, outpath in vcf_out_dict.items():
-            j: PythonJob = vds_to_vcf(cohort=cohort, vds_path=vds_path, vcf_outpath=outpath, chroms=[chrom])
+            j: PythonJob = vds_to_vcf(cohort=cohort, vds_path=vds_path, vcf_outpath=str(outpath), chroms=chrom)
 
         return self.make_outputs(target=cohort, data=vcf_out_dict, jobs=j)

--- a/src/sandbox/stages.py
+++ b/src/sandbox/stages.py
@@ -64,7 +64,9 @@ class ExportVdsToVcf(CohortStage):
         vcf_out_dict: dict[str, cpg_utils.Path] = self.expected_outputs(cohort=cohort)
         vds_path: str = config_retrieve(['export_vds_to_vcf', 'vds_path'])
 
+        jobs = []
         for chrom, outpath in vcf_out_dict.items():
             j: PythonJob = vds_to_vcf(cohort=cohort, vds_path=vds_path, vcf_outpath=str(outpath), chroms=chrom)
+            jobs.append(j)
 
-        return self.make_outputs(target=cohort, data=vcf_out_dict, jobs=j)
+        return self.make_outputs(target=cohort, data=vcf_out_dict, jobs=jobs)


### PR DESCRIPTION
# Purpose

  - Exporting a VDS to VCF. Remove checking of `'*'` as a representation of spanning deletions

## Proposed Changes

- Drop logic that checks for `'*'` alleles, since these are not present in our callset (see explanation below).
- Switch from producing a single large VCF to creating one VDS→VCF job per chromosome and exporting per-chromosome VCFs.


### Spanning Deletions Explained
In the code that generates the `info_ht` (as borrowed from `site_only_vcf.py` in Large Cohorts) there is a comment that indicates possible edge cases with spanning deletions:
```python
# Filter to only non-reference sites.
# An example of a variant with hl.len(mt.alleles) > 1 BUT NOT
# hl.agg.any(mt.LGT.is_non_ref()) is a variant that spans a deletion,
# which was however filtered out, so the LGT was set to NA, however the site
# was preserved to account for the presence of that spanning deletion.
# locus   alleles    LGT
# chr1:1 ["GCT","G"] 0/1
# chr1:3 ["T","*"]   NA
```

This raised the question of whether `'*'` spanning deletions needed to be handled when exporting to VCF.
During testing, it appeared that no such alleles existed in the VDS. To confirm, I inspected multiallelic sites directly in a Jupyter notebook. At one site, a sample was heterozygous non-reference for both a deletion and an insertion:

```
locus   alleles    LGT
chr1:50481  ["GGTGTGTGT","G","GGTGTGT","GGTGTGTGTGT",...] 1/3
```

As seen above, Hail is representing all overlapping variation within a single multiallelic site anchored at the leftmost position, thereby preserving HaploTypeCaller's representation.

The absence of `'*'` alleles in our data is not a Hail artefact — it’s expected given our pipeline configuration. Specifically, in the [Genotype stage](https://github.com/populationgenomics/production-pipelines/blob/986bc0427eed94dce9827bc6d97f656422120ce1/cpg_workflows/jobs/genotype.py#L232) we set:
```
--disable-spanning-event-genotyping
```

According to the [docs for HaployTypeCaller](https://gatk.broadinstitute.org/hc/en-us/articles/360056969012-HaplotypeCaller#--disable-spanning-event-genotyping) this flag disables the inclusion of the `'*'` spanning event when genotyping deletions.